### PR TITLE
my openshift doesn't has OPENSHIFT_INTERNAL_PORT and OPENSHIFT_INTERNAL_IP

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
-var PORT = process.env.OPENSHIFT_INTERNAL_PORT || 8080;
-var IPADDRESS = process.env.OPENSHIFT_INTERNAL_IP || '127.0.0.1';
+var PORT = process.env.OPENSHIFT_INTERNAL_PORT || process.env.OPENSHIFT_NODEJS_PORT  || 8080;
+var IPADDRESS = process.env.OPENSHIFT_INTERNAL_IP || process.env.OPENSHIFT_NODEJS_IP || '127.0.0.1';
 
 var express = require('express');
 var server;


### PR DESCRIPTION
use OPENSHIFT_NODEJS_IP and OPENSHIFT_NODEJS_PORT if OPENSHIFT_INTERNAL_PORT or OPENSHIFT_INTERNAL_IP is unavailable.
